### PR TITLE
jib: relax constraints to allow construction of simple spinnaker

### DIFF
--- a/src/formsaildef.cpp
+++ b/src/formsaildef.cpp
@@ -1063,29 +1063,11 @@ bool CFormSailDef::check()
         txtSheetAngle->setPalette( palHi);
         saildef->sheetDeg = 45;
     }
-    else
-    {
-        txtSheetAngle->setPalette( palStd);
-    }
-
-    switch (saildef->sailType ) // set lower limit for sheeting main or jib
-    {
-    case MAINSAIL:
-        L2 = 0;
-        break;
-    case JIB:
-        L2 = 5;
-        break;
-    case WING:
-        L2 = 0;
-        break;
-    }
-
-    if (saildef->sheetDeg < L2)
+    else if (saildef->sheetDeg < 0)
     {
         flag=false;
         txtSheetAngle->setPalette( palLo);
-        saildef->sheetDeg = L2;
+        saildef->sheetDeg = 0;
     }
     else
     {

--- a/src/widgetprofile.cpp
+++ b/src/widgetprofile.cpp
@@ -148,7 +148,7 @@ CWidgetProfile::CWidgetProfile( QWidget *parent, CProfile *ptr,
 
     spinLuff = new QSpinBox( grpProfile );
     spinLuff->setMaximum( 18 );
-    spinLuff->setMinimum( 1 );
+    spinLuff->setMinimum( 0 );
     spinLuff->setValue( 1 );
     spinBoxesLayout->addWidget( spinLuff );
     QSpacerItem* spacer = new QSpacerItem( 20, 20, QSizePolicy::MinimumExpanding, QSizePolicy::Minimum );
@@ -160,7 +160,7 @@ CWidgetProfile::CWidgetProfile( QWidget *parent, CProfile *ptr,
     spinBoxesLayout->addWidget( lblDepth );
 
     spinDepth = new QSpinBox( grpProfile );
-    spinDepth->setMaximum( 22 );
+    spinDepth->setMaximum( 40 );
     spinDepth->setMinimum( 1 );
     spinDepth->setValue( 10 );
     spinBoxesLayout->addWidget( spinDepth );


### PR DESCRIPTION
This change relax constraints for jib construction. It is able then design simple running spinnaker. It is not perfect, but for basic experiments it is fine.

This will allow symmetric and deeper profile. And also allow sheeting degree to 0 for jib.