### PR TITLE
Increase luff length limit for balanced lug sails

### DIFF
--- a/src/formsaildef.cpp
+++ b/src/formsaildef.cpp
@@ -581,7 +581,7 @@ bool CFormSailDef::check()
         txtLuffRound->setText(QString::number(saildef->luffR) );
 
         /** check main sail foot length against Luff*/
-        L2 = (long)(saildef->luffL);
+        L2 = (long)(saildef->luffL) * 1.5;
         if (saildef->footL > L2)
         {
             flag = false;


### PR DESCRIPTION
Very popular Goat Island Skiff balanced lug sail, for example, uses a luff length quite a bit larger than the foot length.