### PR TITLE
Remove `using namespace std` statements

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -34,8 +34,6 @@
 #include "formsail.h"
 #include "sailwriter-xml.h"
 
-using namespace std;
-
 /**
  * Creates an new Sailcut application.
  *
@@ -227,7 +225,7 @@ QStringList CSailApp::recentDocuments() const
  */
 void CSailApp::addRecentDocument(const QString &filename)
 {
-    vector<QString> &mru = prefs.mruDocuments;
+    std::vector<QString> &mru = prefs.mruDocuments;
     removeRecentDocument(filename);
     mru.insert(mru.begin(), filename);
 
@@ -246,7 +244,7 @@ void CSailApp::addRecentDocument(const QString &filename)
  */
 void CSailApp::removeRecentDocument(const QString &filename)
 {
-    vector<QString> &mru = prefs.mruDocuments;
+    std::vector<QString> &mru = prefs.mruDocuments;
     std::vector<QString>::iterator it = std::find(mru.begin(), mru.end(), filename);
     if (it != mru.end()) {
         mru.erase(it);
@@ -274,7 +272,7 @@ void CSailApp::readPrefs()
     }
     catch (read_error const&)
     {
-        cout << "CSailApp::readPrefs : could not read preferences" << endl;
+        std::cout << "CSailApp::readPrefs : could not read preferences" << std::endl;
     }
 }
 
@@ -290,6 +288,6 @@ void CSailApp::writePrefs()
     }
     catch (write_error const&)
     {
-        cout << "CSailApp::writePrefs : could not write preferences" << endl;
+        std::cout << "CSailApp::writePrefs : could not write preferences" << std::endl;
     }
 }

--- a/src/boatdef-panel.h
+++ b/src/boatdef-panel.h
@@ -47,7 +47,7 @@ public:
 
 protected:
     /** The spin boxes. */
-    vector<QSpinBox *>spinBox;
+    std::vector<QSpinBox*> spinBox;
 
 };
 
@@ -130,7 +130,7 @@ protected:
     QTabWidget *tabs;
 
     /** the widgets for the boat element parameters */
-    vector <CBoatElementWidget*> elementwidget;
+    std::vector<CBoatElementWidget*> elementwidget;
 
     /** the boat definition we are operating one */
     CBoatDef def;

--- a/src/filewriter.h
+++ b/src/filewriter.h
@@ -20,35 +20,28 @@
 #ifndef FILEWRITER_H
 #define FILEWRITER_H
 
-#ifdef WIN32
-#define CRLF   endl
-#else
-#define CRLF "\r\n"
-#endif
-
 #include <iostream>
 #include <stdexcept>
 
 #include <QFileDialog>
 #include <QMessageBox>
 
-using namespace std;
 
-class read_error : public runtime_error
+class read_error : public std::runtime_error
 {
 public:
-    read_error(const string &message) : runtime_error(message)
+    read_error(const std::string &message) : std::runtime_error(message)
     {
-        cout << what() << endl;
+        std::cout << what() << std::endl;
     }
 };
 
-class write_error : public runtime_error
+class write_error : public std::runtime_error
 {
 public:
-    write_error(const string &message) : runtime_error(message)
+    write_error(const std::string &message) : std::runtime_error(message)
     {
-        cout << what() << endl;
+        std::cout << what() << std::endl;
     }
 };
 
@@ -94,7 +87,7 @@ public:
      */
     virtual const objtype read(const QString &) const
     {
-        throw logic_error("Reading is not supported for this file type.");
+        throw std::logic_error("Reading is not supported for this file type.");
     };
 
 

--- a/src/formboat.cpp
+++ b/src/formboat.cpp
@@ -88,7 +88,7 @@ void CFormBoat::add(const QString &newfile)
     }
     else
     {
-        throw invalid_argument("CFormBoat::add : unknown document type");
+        throw std::invalid_argument("CFormBoat::add : unknown document type");
     }
     element.filename = newfile.toStdString();
     def.push_back(element);

--- a/src/formsaildef.cpp
+++ b/src/formsaildef.cpp
@@ -220,7 +220,7 @@ void CFormSailDef::setSailType( enumSailType type )
     {
     case MAINSAIL:
 #ifdef DEBUG
-        cout << "setSailType( MAINSAIL )" << endl;
+        std::cout << "setSailType( MAINSAIL )" << std::endl;
 #endif
         radioMainSail->setChecked( true );
         txtTackDist->setEnabled( true );
@@ -246,7 +246,7 @@ void CFormSailDef::setSailType( enumSailType type )
 
     case JIB:
 #ifdef DEBUG
-        cout << "setSailType( JIB )" << endl;
+        std::cout << "setSailType( JIB )" << std::endl;
 #endif
         radioJib->setChecked( true );
         txtTackDist->setEnabled( false );
@@ -272,7 +272,7 @@ void CFormSailDef::setSailType( enumSailType type )
 
     case WING:
 #ifdef DEBUG
-        cout << "setSailType( WING )" << endl;
+        std::cout << "setSailType( WING )" << std::endl;
 #endif
         radioWing->setChecked( true );
         txtTackDist->setEnabled( true );

--- a/src/geocpp/geocpp.h
+++ b/src/geocpp/geocpp.h
@@ -32,6 +32,4 @@
 #include <geocpp/rect.h>
 #include <geocpp/subspace.h>
 
-using namespace std;
-
 #endif

--- a/src/geocpp/matrix.cpp
+++ b/src/geocpp/matrix.cpp
@@ -212,8 +212,6 @@ CMatrix CMatrix::gaussjordan(bool *is_inv, CMatrix *inv, soltype_t * soltype, st
         for (size_t i = 0; i < m_nrow; ++i)
             b(i, 0) = (*bb)[i];
     }
-    //cout << "b" << endl<< b << endl;
-    //cout << "m" << endl<< *this << endl;
 
     real p_value;
     real p_avalue, avalue;
@@ -345,15 +343,6 @@ CMatrix CMatrix::gaussjordan(bool *is_inv, CMatrix *inv, soltype_t * soltype, st
     {
         if (k < m_ncol)
         {
-            /*
-                  cout << "has non-zero kernel" << endl;
-                  if ((getnrow()==k)) {
-                    // no redundant equations
-                    cout << "getnrow()==k==" << k << endl;
-                  } else {
-                    cout << "getnrow()==" << getnrow() << " k==" << k << endl;
-                  }
-            */
             CMatrix pk = - m.crop(m_ncol-k+1,m_ncol-k,0,k);
             pk = pk.crop(m_ncol,m_ncol-k);
             for (i=0; i + k < m_ncol; i++)
@@ -363,18 +352,15 @@ CMatrix CMatrix::gaussjordan(bool *is_inv, CMatrix *inv, soltype_t * soltype, st
         else
         {
             // matrix is inversible
-            //cout << "m_ncol==k" << endl;
             *tkern = CMatrix();
         }
     }
-    // clean matrix
 
+    // clean matrix
     for (i = 0; i < m_nrow; i++)
         for (j = 0; j < m_ncol; j++)
             if (fabs(m(i,j)) <= EPS)
                 m(i,j) = 0;
-
-    //  return m;
 
     return m.crop(k,m_ncol);
 }

--- a/src/geocpp/subspace.cpp
+++ b/src/geocpp/subspace.cpp
@@ -135,8 +135,6 @@ CSubSpace CSubSpace::intersect(const CSubSpace &h2) const
             bb[i] = b2[i - m.rows()];
         }
     }
-    //cout << "mm" << endl << mm << endl;
-    //cout << "bb" << endl << bb << endl;
 
     soltype_t soltype = NONE;
     CMatrix k;
@@ -147,13 +145,13 @@ CSubSpace CSubSpace::intersect(const CSubSpace &h2) const
     switch (soltype)
     {
     case ONE:
-        //cout << "CMatrix::solve : system has unique solution" << endl;
+        // system has unique solution
         return CSubSpace(s, CMatrix::id(SIZE), GEOCPP_FROM_EQS);
     case INF:
-        //cout << "CMatrix::solve : system has an infinity of solutions" << endl;
+        // system has an infinity of solutions
         return CSubSpace(s, k, GEOCPP_FROM_BASE);
     case NONE:
-        //cout << "CMatrix::solve : system has no solution" << endl;
+        // system has no solution
         break;
     }
     return CSubSpace();
@@ -227,7 +225,7 @@ ostream& operator<< (ostream &o, const CMatrix &m)
     {
         o << m.row(i);
         if ( i != m.rows() - 1 )
-            o << endl;
+            o << std::endl;
     }
     o << "]";
     return o;
@@ -238,36 +236,36 @@ ostream& operator<< (ostream &o, const CMatrix &m)
  */
 ostream& operator<< (ostream &o, const CSubSpace &h)
 {
-    o << "--------------------------------" << endl;
+    o << "--------------------------------" << std::endl;
     o << "     subspace : ";
     switch (h.getdim())
     {
     case -1:
-        o << "empty" << endl;
+        o << "empty" << std::endl;
         break;
     case 0:
-        o << "point" << endl;
+        o << "point" << std::endl;
         break;
     case 1:
-        o << "line" << endl;
+        o << "line" << std::endl;
         break;
     case 2:
-        o << "plane" << endl;
+        o << "plane" << std::endl;
         break;
     default:
-        o << "dim=" << h.getdim() << endl;
+        o << "dim=" << h.getdim() << std::endl;
     }
-    o << "--------------------------------" << endl;
+    o << "--------------------------------" << std::endl;
     if ( h.getdim() >= 0 )
     {
-        o << "point:" << endl << h.getp() << endl;
+        o << "point:" << std::endl << h.getp() << std::endl;
         if (h.getdim()>0)
         {
-            o << "------" << endl;
-            o << "base vectors (in columns): " << endl << h.getm().kern(h.getp().size()) << endl << "------" << endl;
-            o << "equations (coeffs in lines): " << endl << h.getm() << endl;
+            o << "------" << std::endl;
+            o << "base vectors (in columns): " << std::endl << h.getm().kern(h.getp().size()) << std::endl << "------" << std::endl;
+            o << "equations (coeffs in lines): " << std::endl << h.getm() << std::endl;
         }
-        o << "--------------------------------" << endl;
+        o << "--------------------------------" << std::endl;
     }
     return o;
 }

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -23,8 +23,6 @@
 #include <vector>
 #include <QString>
 
-using namespace std;
-
 /**
  * A class used to store a user's preferences.
  */
@@ -34,7 +32,7 @@ public:
     CPrefs();
 
     /** The most recently used documents. */
-    vector<QString> mruDocuments;
+    std::vector<QString> mruDocuments;
 
     /** The width of the main window */
     int mainWindowWidth;

--- a/src/sailcpp/boatdef.h
+++ b/src/sailcpp/boatdef.h
@@ -37,7 +37,7 @@ public:
     /** the type of file this element was read from (sail, hull definition or 3D panels) */
     enumBoatElementType type;
     /** the name of the file this element was read from */
-    string filename;
+    std::string filename;
     /** the origin of the element */
     CPoint3d origin;
 };
@@ -48,7 +48,7 @@ public:
  *
  * @see CBoatElement
  */
-class CBoatDef : public vector<CBoatElement>
+class CBoatDef : public std::vector<CBoatElement>
 {
 public:
     CBoatDef();

--- a/src/sailcpp/hulldef.h
+++ b/src/sailcpp/hulldef.h
@@ -36,7 +36,7 @@ public:
     CHullDef();
 
     /** hull ID name */
-    string hullID;
+    std::string hullID;
 
         //deck
     /** deck Length in millimeter */

--- a/src/sailcpp/panel.cpp
+++ b/src/sailcpp/panel.cpp
@@ -452,25 +452,25 @@ void CPanel::add6Hems( const real &lolW, const real &hilW, const real &topW, con
 
     ///* compute basic edges vectors */
     CVector3d v1 = left[npl/2] - left[0];
-    //  if ( v1.length() == 0 ) cout << "CPanel::add6Hems v1=0 " << endl;
+    //  if ( v1.length() == 0 ) std::cout << "CPanel::add6Hems v1=0 " << std::endl;
     CVector3d v2 = left[npl-1] - left[npl/2];
-    //  if ( v2.length() == 0 ) cout << "CPanel::add6Hems v2=0 " << endl;
+    //  if ( v2.length() == 0 ) std::cout << "CPanel::add6Hems v2=0 " << std::endl;
     CVector3d v3 = right[npl/2] - right[0];
-    //  if ( v3.length() == 0 ) cout << "CPanel::add6Hems v3=0 " << endl;
+    //  if ( v3.length() == 0 ) std::cout << "CPanel::add6Hems v3=0 " << std::endl;
     CVector3d v4 = right[npl-1] - right[npl/2];
-    //  if ( v4.length() == 0 ) cout << "CPanel::add6Hems v4=0 " << endl;
+    //  if ( v4.length() == 0 ) std::cout << "CPanel::add6Hems v4=0 " << std::endl;
     CVector3d v5 = bottom[npb-1] - bottom[0];
-    //  if ( v5.length() == 0 ) cout << "CPanel::add6Hems v5=0 " << endl;
+    //  if ( v5.length() == 0 ) std::cout << "CPanel::add6Hems v5=0 " << std::endl;
     CVector3d v6 = bottom[npb-1] - bottom[npb-2];
-    //  if ( v6.length() == 0 ) cout << "CPanel::add6Hems v6=0 " << endl;
+    //  if ( v6.length() == 0 ) std::cout << "CPanel::add6Hems v6=0 " << std::endl;
     CVector3d v7 = top[npb-1] - top[0];
-    //  if ( v7.length() == 0 ) cout << "CPanel::add6Hems v7=0 " << endl;
+    //  if ( v7.length() == 0 ) std::cout << "CPanel::add6Hems v7=0 " << std::endl;
     CVector3d v8 = top[npb-1] - top[npb-2];
-    //  if ( v8.length() == 0 ) cout << "CPanel::add6Hems v8=0 " << endl <<endl;
+    //  if ( v8.length() == 0 ) std::cout << "CPanel::add6Hems v8=0 " << std::endl <<std::endl;
 
-    //cout << "CPanel::add6Hems start" << endl;
-    //cout << "   lolW=" << lolW << " hilW=" << hilW << "   topW =" << topW <<  endl;
-    //cout << "   lorW=" << lorW << " hirW=" << hirW << "   botW=" << botW << endl;
+    //std::cout << "CPanel::add6Hems start" << std::endl;
+    //std::cout << "   lolW=" << lolW << " hilW=" << hilW << "   topW =" << topW <<  std::endl;
+    //std::cout << "   lorW=" << lorW << " hirW=" << hirW << "   botW=" << botW << std::endl;
 
     ///* copy the basic panel edge points to cut points as default */
     for (i = 0 ; i < npl ; i++) {
@@ -503,7 +503,7 @@ void CPanel::add6Hems( const real &lolW, const real &hilW, const real &topW, con
     }
 
     ///* Move the basic bottom edge points to the cut line */
-    //cout << "CPanel::add6Hems move basic bottom edge" << endl;
+    //std::cout << "CPanel::add6Hems move basic bottom edge" << std::endl;
 
     if ( botW > EPS ) { // width of material is not too small
         for (i = 0 ; i < npb ; i++) {
@@ -558,7 +558,7 @@ void CPanel::add6Hems( const real &lolW, const real &hilW, const real &topW, con
 
                     if ( Line1.intersect(Line2).getdim() == 0 )
                         cutLeft[npl/2] = Line1.intersect(Line2).getp();
-                    // else cout << "CPanel::add6Hems = no mid left side intersection point" << endl;
+                    // else std::cout << "CPanel::add6Hems = no mid left side intersection point" << std::endl;
 
                     // check adjacent points relative to mid side point
                     if (CVector3d::dotProduct(cutLeft[npl/2] - cutLeft[npl/2 -1], v0) <= 0)
@@ -602,7 +602,7 @@ void CPanel::add6Hems( const real &lolW, const real &hilW, const real &topW, con
         for (i = 0 ; i< npl ; i++)
             cutLeft[i] = left[i] + v.normalized() * lolW;
 
-        // if (v.length() == 0) cout << "CPanel::add6Hems 10 v=0 v5="<< v5.length()<< " v7="<< v7.length()<< endl;
+        // if (v.length() == 0) std::cout << "CPanel::add6Hems 10 v=0 v5="<< v5.length()<< " v7="<< v7.length()<< std::endl;
         v1 = rotateNormalized(-M_PI/2, v);
         v2 = v1;
     }
@@ -643,7 +643,7 @@ void CPanel::add6Hems( const real &lolW, const real &hilW, const real &topW, con
 
                     if (Line1.intersect(Line2).getdim() == 0)
                         cutRight[npl/2] = Line1.intersect(Line2).getp();
-                    // else cout << "CPanel::add6Hems = no mid right side intersection point" << endl;
+                    // else std::cout << "CPanel::add6Hems = no mid right side intersection point" << std::endl;
 
                     // check adjacent points relative to mid side point
                     if (CVector3d::dotProduct(cutRight[npl/2] - cutRight[npl/2 -1], v0) <= 0)
@@ -668,9 +668,9 @@ void CPanel::add6Hems( const real &lolW, const real &hilW, const real &topW, con
         //v3 = right[npl-2] - right[npl/2];
         /*        if (v3.length() == 0)
                 {
-                        cout << "AddHems v3=0 : about to crash 13" << endl;
+                        std::cout << "AddHems v3=0 : about to crash 13" << std::endl;
                     for (i = 0 ; i < npl ; i++)
-                        cout << "pt " << i << " xyz= " << right[i] << endl;
+                        std::cout << "pt " << i << " xyz= " << right[i] << std::endl;
                 }
         */
         for (i = 0 ; i < npl/2  ; i++)
@@ -680,7 +680,7 @@ void CPanel::add6Hems( const real &lolW, const real &hilW, const real &topW, con
             cutRight[i] = right[i] + rotateNormalized(-M_PI/2, v4) * hirW;
 
         v4 = right[npl-1] - right[npl-2];
-        //    if (v4.length() == 0) cout << "AddHems v4=0 about to crash 13" << endl;
+        //    if (v4.length() == 0) std::cout << "AddHems v4=0 about to crash 13" << std::endl;
     }
     else {  // complete right side is a point
         if ( botW == 0 )
@@ -688,7 +688,7 @@ void CPanel::add6Hems( const real &lolW, const real &hilW, const real &topW, con
         else
             v = ( v6 + v8 );
 
-        if (v.length() == 0) cout << "CPanel::add6Hems v=v6=0 or v=v6+v8=0 about to crash 14" << endl;
+        if (v.length() == 0) std::cout << "CPanel::add6Hems v=v6=0 or v=v6+v8=0 about to crash 14" << std::endl;
 
         for (i = 0 ; i< npl ; i++)
             cutRight[i] = right[i] + v.normalized() * lorW;
@@ -698,14 +698,14 @@ void CPanel::add6Hems( const real &lolW, const real &hilW, const real &topW, con
     }
 
     ///* Rejoining the 4 corners of the cut panel */
-    // cout << "Rejoining 4 corners" << endl;
+    // std::cout << "Rejoining 4 corners" << std::endl;
     /// lower left
     if (v5.length() == 0)
-        cout << "CPanel::add6Hems v5=0 about to crash 15" << endl;
+        std::cout << "CPanel::add6Hems v5=0 about to crash 15" << std::endl;
     Line1 = CSubSpace::line( cutBottom[0] , v5 );
 
     if (v6.length() == 0)
-        cout << "CPanel::add6Hems v6=0 about to crash 16" << endl;
+        std::cout << "CPanel::add6Hems v6=0 about to crash 16" << std::endl;
     Line2 = CSubSpace::line( cutLeft[0] , v1 );
 
     pt = Line1.intersectionPoint(Line2, "lower left corner");
@@ -778,7 +778,7 @@ void CPanel::add6Hems( const real &lolW, const real &hilW, const real &topW, con
     /* Scan the first few points of the cut edges to make sure
      * that they are not on the wrong side of the intersect point pt
      */
-    // cout << "CPanel::add6Hems scan for overlap " << endl;
+    // std::cout << "CPanel::add6Hems scan for overlap " << std::endl;
     for (i = 1 ; i < npl/2 ; i++) {
         if (CVector3d::dotProduct(cutRight[npl-1-i] - pt, v4) >= 0)
             cutRight[npl-1-i] = pt;
@@ -786,7 +786,7 @@ void CPanel::add6Hems( const real &lolW, const real &hilW, const real &topW, con
         if (CVector3d::dotProduct(cutTop[npb-1-i] - pt, v6) >= 0)
             cutTop[npb-1-i] = pt;
     }
-    // cout << "End CPanel::add6Hems" << endl << endl;
+    // std::cout << "End CPanel::add6Hems" << std::endl << std::endl;
 } /// end add6Hems ////////////////////////////////////////
 
 
@@ -950,47 +950,47 @@ CSide CSide::transformed(const CMatrix4x4 &m) const
  *********************************************/
 
 /** Outputs a CPanel  to a stream.
- *  exemple:  cout << panel[i];
+ *  exemple:  std::cout << panel[i];
  */
-ostream& operator<<(ostream& o , const CPanel &p)
+std::ostream& operator<<(std::ostream& o , const CPanel &p)
 {
     o << p.label;
-    o << "== CSide : left ==" << endl << p.left;
-    o << "== CSide : top ==" << endl << p.top;
-    o << "== CSide : right ==" << endl << p.right;
-    o << "== CSide : bottom ==" << endl << p.bottom;
+    o << "== CSide : left ==" << std::endl << p.left;
+    o << "== CSide : top ==" << std::endl << p.top;
+    o << "== CSide : right ==" << std::endl << p.right;
+    o << "== CSide : bottom ==" << std::endl << p.bottom;
 
     if ( p.hasHems )
     {
-        o << "== CSide : cutLeft ==" << endl << p.cutLeft;
-        o << "== CSide : cutTop ==" << endl << p.cutTop;
-        o << "== CSide : cutRight ==" << endl << p.cutRight;
-        o << "== CSide : cutBottom ==" << endl << p.cutBottom;
+        o << "== CSide : cutLeft ==" << std::endl << p.cutLeft;
+        o << "== CSide : cutTop ==" << std::endl << p.cutTop;
+        o << "== CSide : cutRight ==" << std::endl << p.cutRight;
+        o << "== CSide : cutBottom ==" << std::endl << p.cutBottom;
     }
     return o;
 }
 
 /** Outputs a CPanelLabel  to a stream.
- *  exemple:  cout << panel[i].label;
+ *  exemple:  std::cout << panel[i].label;
  */
-ostream& operator<< (ostream &o , const CPanelLabel &lb)
+std::ostream& operator<< (std::ostream &o , const CPanelLabel &lb)
 {
-    o << "== CPanelLabel : name ==" << endl << lb.name << endl;
-    o << "== CPanelLabel : height ==" << endl << lb.height << endl;
-    o << "== CPanelLabel : color ==" << endl << lb.color << endl;
-    o << "== CPanelLabel : origin ==" << endl << lb.origin << endl;
-    o << "== CPanelLabel : direction ==" << endl << lb.direction << endl;
+    o << "== CPanelLabel : name ==" << std::endl << lb.name << std::endl;
+    o << "== CPanelLabel : height ==" << std::endl << lb.height << std::endl;
+    o << "== CPanelLabel : color ==" << std::endl << lb.color << std::endl;
+    o << "== CPanelLabel : origin ==" << std::endl << lb.origin << std::endl;
+    o << "== CPanelLabel : direction ==" << std::endl << lb.direction << std::endl;
     return o;
 }
 
 /** Outputs a CSide  to a stream.
- *  exemple:  cout << panel[i].left;
+ *  exemple:  std::cout << panel[i].left;
  */
-ostream& operator<< (ostream &out, const CSide &s)
+std::ostream& operator<< (std::ostream &out, const CSide &s)
 {
     for (unsigned int i = 0 ; i < s.size() ; i++)
     {
-        out << "#" << i << "\t" << s[i] << endl;
+        out << "#" << i << "\t" << s[i] << std::endl;
     }
     return out;
 }

--- a/src/sailcpp/panel.h
+++ b/src/sailcpp/panel.h
@@ -31,12 +31,12 @@ enum enumPointType { LUFF, FOOT, LEECH, GAFF };
 enum enumAlign {LEFT, LOW_LEFT, BOTTOM};
 enum enumDevelopAlign {ALIGN_TOP,ALIGN_BOTTOM };
 
-class panel_error : public runtime_error
+class panel_error : public std::runtime_error
 {
 public:
-    panel_error(const string &message) : runtime_error(message)
+    panel_error(const std::string &message) : std::runtime_error(message)
     {
-        cout << "in panel: " << what()  << endl;
+        std::cout << "in panel: " << what() << std::endl;
     }
 };
 
@@ -54,7 +54,7 @@ public:
     CPanelLabel( const CPanelLabel& );
 
     /** label name of the panel */
-    string name;
+    std::string name;
 
     /** label text height (default : 5) */
     int height;
@@ -73,7 +73,7 @@ public:
     /** operator to copy a label */
     CPanelLabel& operator=( const CPanelLabel &);
 
-    friend ostream& operator<< (ostream &, const CPanelLabel &);
+    friend std::ostream& operator<< (std::ostream &, const CPanelLabel &);
 };
 
 
@@ -87,7 +87,7 @@ public:
  *
  * @ingroup SailCpp
  */
-class CSide : public vector<CPoint3d>
+class CSide : public std::vector<CPoint3d>
 {
 public:
     CSide( unsigned int = 1 );
@@ -99,7 +99,7 @@ public:
     CSide transformed(const CMatrix4x4 &m) const;
 
     // operators
-    friend ostream& operator<< (ostream &, const CSide &);
+    friend std::ostream& operator<< (std::ostream &, const CSide &);
 };
 
 
@@ -180,13 +180,13 @@ public:
     CPanel operator+ (const CVector3d &) const;
     CPanel& operator= (const CPanel &);
 
-    friend ostream& operator<< (ostream &, const CPanel &);
+    friend std::ostream& operator<< (std::ostream &, const CPanel &);
 };
 
 // global functions
-ostream& operator<< (ostream &, const CPanel &);
-ostream& operator<< (ostream &, const CSide &);
-ostream& operator<< (ostream &, const CPanelLabel &);
+std::ostream& operator<< (std::ostream &, const CPanel &);
+std::ostream& operator<< (std::ostream &, const CSide &);
+std::ostream& operator<< (std::ostream &, const CPanelLabel &);
 
 CVector3d rotateNormalized(real angle, const CVector3d &v);
 

--- a/src/sailcpp/panelgroup.cpp
+++ b/src/sailcpp/panelgroup.cpp
@@ -31,7 +31,7 @@ CPanelGroup::CPanelGroup( unsigned int nbpanels /* = 0 */)
 /** Copy constructor.
  */
 CPanelGroup::CPanelGroup( const CPanelGroup& s )
-        : vector<CPanel>(s)
+        : std::vector<CPanel>(s)
 {
     title = s.title;
     child = s.child;
@@ -128,7 +128,7 @@ CPanelGroup& CPanelGroup::operator=(const CPanelGroup& s)
     if (&s == this)
         return *this;
 
-    this->vector<CPanel>::operator=(s);
+    this->std::vector<CPanel>::operator=(s);
     title = s.title;
     child = s.child;
     type = s.type;
@@ -139,18 +139,18 @@ CPanelGroup& CPanelGroup::operator=(const CPanelGroup& s)
 
 /** Outputs a CPanelGroup to a stream.
  */
-ostream& operator<<(ostream &o, const CPanelGroup &s)
+std::ostream& operator<<(std::ostream &o, const CPanelGroup &s)
 {
     unsigned int i;
     for (i = 0; i < s.size(); i++)
     {
-        o << "===== CPanel : " << i << " ====" << endl;
-        o << s[i] << endl;
+        o << "===== CPanel : " << i << " ====" << std::endl;
+        o << s[i] << std::endl;
     }
     for (i = 0; i < s.child.size(); i++)
     {
-        o << "===== child CPanelGroup : " << i << " ====" << endl;
-        o << s.child[i] << endl;
+        o << "===== child CPanelGroup : " << i << " ====" << std::endl;
+        o << s.child[i] << std::endl;
     }
     return o;
 }

--- a/src/sailcpp/panelgroup.h
+++ b/src/sailcpp/panelgroup.h
@@ -29,7 +29,7 @@ enum enumPanelGroupType { SAIL, RIG, HULL };
  *
  * @ingroup SailCpp
  */
-class CPanelGroup : public vector<CPanel>
+class CPanelGroup : public std::vector<CPanel>
 {
 public:
     CPanelGroup( unsigned int = 0 );
@@ -37,10 +37,10 @@ public:
     CPanelGroup( const CPanel& );
 
     /** title of this panel group */
-    string title;
+    std::string title;
 
     /** children of this group */
-    vector<CPanelGroup> child;
+    std::vector<CPanelGroup> child;
 
     /** type of boat object */
     enumPanelGroupType type;
@@ -59,11 +59,11 @@ public:
 
     // operators
     CPanelGroup& operator=( const CPanelGroup &);
-    friend ostream& operator<< (ostream &, const CPanelGroup &);
+    friend std::ostream& operator<< (std::ostream &, const CPanelGroup &);
 };
 
 
 // global functions
-ostream& operator<< (ostream &, const CPanelGroup &);
+std::ostream& operator<< (std::ostream &, const CPanelGroup &);
 
 #endif

--- a/src/sailcpp/rigdef.h
+++ b/src/sailcpp/rigdef.h
@@ -36,7 +36,7 @@ public:
     CRigDef();
 
     /** rig ID name */
-    string rigID;
+    std::string rigID;
     /** fore triangle hoist*/
     real foreI;
     /** fore triangle base*/

--- a/src/sailcpp/saildef.h
+++ b/src/sailcpp/saildef.h
@@ -44,7 +44,7 @@ public:
 
     // member variables
     /** The Sail ID name */
-    string sailID;
+    std::string sailID;
     /** The type of cut layout */
     enumSailCut sailCut;
     /** The type of sail */

--- a/src/sailcpp/sailmould.cpp
+++ b/src/sailcpp/sailmould.cpp
@@ -22,8 +22,6 @@
 
 #include "sailmould.h"
 
-using namespace std;
-
 /**************************************************************************
                              CProfile class
 ***************************************************************************
@@ -258,7 +256,7 @@ CSailMould::CSailMould()
 CProfile CSailMould::interpol ( const real h ) const
 {
     if ( profile.size() < 3)
-        cout << "profile < 3 !!" << endl;
+        std::cout << "profile < 3 !!" << std::endl;
 
     CProfile p;
     real pv = real(vertpos) / 100;

--- a/src/sailcpp/sailmould.h
+++ b/src/sailcpp/sailmould.h
@@ -23,8 +23,6 @@
 #include <geocpp/geocpp.h>
 #include <vector>
 
-using namespace std;
-
 /** Class used to work on sail profiles.
  *
  * @ingroup SailCpp
@@ -114,7 +112,7 @@ public:
 
     /** the mould's profiles ( top, middle, bottom ) */
     //  CProfile profile[3];
-    vector<CProfile> profile;
+    std::vector<CProfile> profile;
 
     /** vertical position of profile[1] in percent */
     int vertpos;

--- a/src/sailcpp/sailworker.cpp
+++ b/src/sailcpp/sailworker.cpp
@@ -277,9 +277,9 @@ CPanelGroup CSailWorker::Layout0( CPanelGroup &flatsail, CPanelGroup &dispsail )
     CVector3d vk(0, 0, 0);
 
     /* create variable for edge correction */
-    vector<CVector3d> deviation;
+    std::vector<CVector3d> deviation;
     deviation.resize(npb);
-    vector<CVector3d> deviaPrev;
+    std::vector<CVector3d> deviaPrev;
     deviaPrev.resize(npb);
 
     /* Other edge hem width */
@@ -457,9 +457,9 @@ CPanelGroup CSailWorker::Layout0( CPanelGroup &flatsail, CPanelGroup &dispsail )
 #ifdef DEBUG
                 if ( npanel == 1 )
                 {
-                    cout << "CSailWorker::Layout0 Crosscut foot after adding curve" << endl;
+                    std::cout << "CSailWorker::Layout0 Crosscut foot after adding curve" << std::endl;
                     for (k = 0 ; k < npb ; k++)
-                        cout << "pt="<< k << " xyz=" << lay[0].bottom[k] << endl;
+                        std::cout << "pt="<< k << " xyz=" << lay[0].bottom[k] << std::endl;
                 }
 #endif
             }  /* end else normal panel */
@@ -470,11 +470,11 @@ CPanelGroup CSailWorker::Layout0( CPanelGroup &flatsail, CPanelGroup &dispsail )
 #ifdef DEBUG
             if ( npanel == 1 )
             { // move bottom side of first panel to foot curve
-                cout << "CSailWorker::Layout0 Crosscut foot after Z " << endl;
+                std::cout << "CSailWorker::Layout0 Crosscut foot after Z " << std::endl;
                 for (k = 0 ; k < npb ; k++)
-                    cout << "pt="<< k << " xyz=" << lay[0].bottom[k] << endl;
+                    std::cout << "pt="<< k << " xyz=" << lay[0].bottom[k] << std::endl;
 
-                cout << "---end Z foot----   DO LOOP=" << cnt << endl;
+                std::cout << "---end Z foot----   DO LOOP=" << cnt << std::endl;
             }
 #endif
 
@@ -613,9 +613,9 @@ CPanelGroup CSailWorker::LayoutTwist( CPanelGroup &flatsail, CPanelGroup &dispsa
     CVector3d vk(0, 0, 0);
 
     /* create variable for edge correction */
-    vector<CVector3d> deviation;
+    std::vector<CVector3d> deviation;
     deviation.resize(npb);
-    vector<CVector3d> deviaPrev;
+    std::vector<CVector3d> deviaPrev;
     deviaPrev.resize(npb);
 
     /* seam 0 is on the foot of the sail ending at the clew */
@@ -696,12 +696,12 @@ CPanelGroup CSailWorker::LayoutTwist( CPanelGroup &flatsail, CPanelGroup &dispsa
                     seamLT = CSubSpace::line(p2[npanel] , seamVT);
                     ip = seamLT.intersectionPoint(luffLine, "seamLT and luff");
 #ifdef DEBUG
-                    cout << "CSailWorker::LayoutTwist Seam 1 LUFF CORRECTION DO LOOP = " << cnt << endl;
-                    cout << " ip = " << ip << endl;
-                    cout << "p1[0] " << p1[0] << "  p2[0] " << p2[0] << " type "<< t1[0] << t2[0] << endl;
-                    cout << "p1[1] " << p1[1] << "  p2[1] " << p2[1] << " type "<< t1[1] << t2[1] << endl;
-                    cout << "seam VT = " << seamVT << endl;
-                    cout << "--- " << endl;
+                    std::cout << "CSailWorker::LayoutTwist Seam 1 LUFF CORRECTION DO LOOP = " << cnt << std::endl;
+                    std::cout << " ip = " << ip << std::endl;
+                    std::cout << "p1[0] " << p1[0] << "  p2[0] " << p2[0] << " type "<< t1[0] << t2[0] << std::endl;
+                    std::cout << "p1[1] " << p1[1] << "  p2[1] " << p2[1] << " type "<< t1[1] << t2[1] << std::endl;
+                    std::cout << "seam VT = " << seamVT << std::endl;
+                    std::cout << "--- " << std::endl;
 #endif
                 }
                 else if (CVector3d::dotProduct(ip - head, luffV) > 0)
@@ -764,9 +764,9 @@ CPanelGroup CSailWorker::LayoutTwist( CPanelGroup &flatsail, CPanelGroup &dispsa
 #ifdef DEBUG
                 if ( npanel == 1 )
                 {
-                    cout << "CSailWorker::LaoutTwist foot straight  - LOOP= "<< cnt << endl;
+                    std::cout << "CSailWorker::LaoutTwist foot straight  - LOOP= "<< cnt << std::endl;
                     for (k = 0 ; k < npb ; k++)
-                        cout << "pt="<< k << " Bottom xyz= " << lay[0].bottom[k] << " Top xyz= " << lay[0].top[k] << endl;
+                        std::cout << "pt="<< k << " Bottom xyz= " << lay[0].bottom[k] << " Top xyz= " << lay[0].top[k] << std::endl;
                 }
 #endif
 
@@ -822,11 +822,11 @@ CPanelGroup CSailWorker::LayoutTwist( CPanelGroup &flatsail, CPanelGroup &dispsa
 #ifdef DEBUG
             if ( npanel == 1 )
             { // move bottom side of first panel to foot curve
-                cout << "CSailWorker::LayoutTwist foot after adding seams " << endl;
+                std::cout << "CSailWorker::LayoutTwist foot after adding seams " << std::endl;
                 for (k = 0 ; k < npb ; k++)
-                    cout << "pt="<< k << " xyz=" << dev[0].bottom[k] << endl;
+                    std::cout << "pt="<< k << " xyz=" << dev[0].bottom[k] << std::endl;
 
-                cout << "------END LOOP="<< cnt << endl;
+                std::cout << "------END LOOP="<< cnt << std::endl;
             }
 #endif
 
@@ -917,9 +917,9 @@ CPanelGroup CSailWorker::LayoutVertical( CPanelGroup &flatsail, CPanelGroup &dis
     CVector3d vk(0, 0, 0);
 
     /* create variable for panel width correction */
-    vector<CVector3d> deviation;
+    std::vector<CVector3d> deviation;
     deviation.resize(npb);
-    vector<CVector3d> deviaPrev;
+    std::vector<CVector3d> deviaPrev;
     deviaPrev.resize(npb);
 
     /* Other edge hem width */
@@ -1146,9 +1146,9 @@ CPanelGroup CSailWorker::LayoutWing( CPanelGroup &flatsail, CPanelGroup &dispsai
     CVector3d vk(0, 0, 0);
 
     /* create variable for edge correction */
-    vector<CVector3d> deviation;
+    std::vector<CVector3d> deviation;
     deviation.resize(npb);
-    vector<CVector3d> deviaPrev;
+    std::vector<CVector3d> deviaPrev;
     deviaPrev.resize(npb);
 
     /* Other edge hem width */
@@ -1468,7 +1468,7 @@ CPanelGroup CSailWorker::LayoutRadial( CPanelGroup &flatsail, CPanelGroup &disps
     CVector3d vk(0, 0, 0);
 
     /* create variable for edge correction */
-    vector<CVector3d> deviation;
+    std::vector<CVector3d> deviation;
     deviation.resize(npb);
 
     /* Other edge hem width */
@@ -1962,7 +1962,7 @@ CPanelGroup CSailWorker::LayoutTriRadial( CPanelGroup &flatsail, CPanelGroup &di
     CVector3d vk(0, 0, 0);
 
     /* create variable for edge correction */
-    vector<CVector3d> deviation;
+    std::vector<CVector3d> deviation;
     deviation.resize(npb);
 
     /* Create arrays of points at horizontal seams ends 10 maximum */
@@ -2421,9 +2421,9 @@ CPanelGroup CSailWorker::LayoutMitre( CPanelGroup &flatsail, CPanelGroup &dispsa
     CVector3d vk(0, 0, 0);
 
     /* create variable for edge correction */
-    vector<CVector3d> deviation;
+    std::vector<CVector3d> deviation;
     deviation.resize(npb);
-    vector<CVector3d> deviaPrev;
+    std::vector<CVector3d> deviaPrev;
     deviaPrev.resize(npb);
 
     /** Mitre Hem Width is set at twice the Seam Width. */
@@ -2502,7 +2502,7 @@ CPanelGroup CSailWorker::LayoutMitre( CPanelGroup &flatsail, CPanelGroup &dispsa
                     lay[npanel-1].right[k] = EdgeIntersect( LUFF_EDGE, lay[npanel-1].right[k], footVP);
             }
             else
-            { // cout <<  "CSailWorker::LayoutMitre full mitre" << endl;
+            { // std::cout <<  "CSailWorker::LayoutMitre full mitre" << std::endl;
                 lay[npanel-1].right.fill(p2[npanel-1], p2[npanel]);
             }
 
@@ -2865,9 +2865,9 @@ CPanelGroup CSailWorker::LayoutMitre2( CPanelGroup &flatsail, CPanelGroup &disps
     CVector3d vk(0, 0, 0);
 
     /* create variable for edge correction */
-    vector<CVector3d> deviation;
+    std::vector<CVector3d> deviation;
     deviation.resize(npb);
-    vector<CVector3d> deviaPrev;
+    std::vector<CVector3d> deviaPrev;
     deviaPrev.resize(npb);
 
     /* create variable to monitor excess over cloth width */
@@ -2890,7 +2890,7 @@ CPanelGroup CSailWorker::LayoutMitre2( CPanelGroup &flatsail, CPanelGroup &disps
 
     for ( npanel = 1; npanel < MAX_PANELS/2-1; npanel++ )
     {
-        // cout << " ----- FOR LOOP foot npanel = " << npanel << endl;
+        // std::cout << " ----- FOR LOOP foot npanel = " << npanel << std::endl;
         exb = 0;
         exc = 0;
         cnt = 0; // reset counter
@@ -2979,7 +2979,7 @@ CPanelGroup CSailWorker::LayoutMitre2( CPanelGroup &flatsail, CPanelGroup &disps
             exb = exb + (0.8 * exc) +1; // sum previous correction + 80% of current excess of width +1mm
 
             if (cnt == cntMax)
-                cout << "CSailcorker::LayoutMitre2  Foot panel " << npanel << " may be wider than cloth by " << exc << "mm." << endl;
+                std::cout << "CSailcorker::LayoutMitre2  Foot panel " << npanel << " may be wider than cloth by " << exc << "mm." << std::endl;
         }
         while ( exc > 0 && cnt < cntMax );
         /* Loop DO as long as the excess of width is positive  AND counter <9 */
@@ -3052,13 +3052,13 @@ CPanelGroup CSailWorker::LayoutMitre2( CPanelGroup &flatsail, CPanelGroup &disps
 
             // fill right side points
             if (t2[npanel-1] == LuffIntersection && t2[npanel] == LuffIntersection) {
-                 // cout << "CSailWorker::LayoutMitre2 full luff" << endl;
+                 // std::cout << "CSailWorker::LayoutMitre2 full luff" << std::endl;
                 lay[npanel-1].right.fill(p2[npanel-1], p2[npanel]);
                 for ( k = 0; k < npl; k++ )
                     lay[npanel-1].right[k]=EdgeIntersect( LUFF_EDGE, lay[npanel-1].right[k], leechV);
             }
             else if (t2[npanel-1] == GaffIntersection && t2[npanel] == LuffIntersection) {
-                // cout << "CSailWorker::LayoutMitre2 gaff-head-luff" << endl;
+                // std::cout << "CSailWorker::LayoutMitre2 gaff-head-luff" << std::endl;
                 lay[npanel-1].right.fill(p2[npanel-1], head, p2[npanel]);
 
                 for ( k = 0; k < npl/2; k++ )
@@ -3068,7 +3068,7 @@ CPanelGroup CSailWorker::LayoutMitre2( CPanelGroup &flatsail, CPanelGroup &disps
                     lay[npanel-1].right[k] = EdgeIntersect( LUFF_EDGE,lay[npanel-1].right[k], leechV);
             }
             else {
-                // cout << "CSailWorker::LayoutMitre2 full gaff << endl;
+                // std::cout << "CSailWorker::LayoutMitre2 full gaff << std::endl;
                 lay[npanel-1].right.fill(p2[npanel-1], p2[npanel]);
 
                 for ( k = 0; k < npl; k++ )
@@ -3132,7 +3132,7 @@ CPanelGroup CSailWorker::LayoutMitre2( CPanelGroup &flatsail, CPanelGroup &disps
             exb = exb + (0.8 * exc) + 1; // sum previous correction + 80% of current excess of width +1mm
 
             if (cnt == cntMax)
-                cout << "CSailWorker::LayoutMitre2  Leech panel " << npanel << " may be wider than cloth by " << exc << "mm." << endl;
+                std::cout << "CSailWorker::LayoutMitre2  Leech panel " << npanel << " may be wider than cloth by " << exc << "mm." << std::endl;
         }
         while ( exc > 0 && cnt < cntMax );
         /* loop DO as long as the excess of width is positive  AND counter <9 */

--- a/src/sailcpp/sailworker.h
+++ b/src/sailcpp/sailworker.h
@@ -29,12 +29,12 @@ class CSeam;
 
 enum enumEdgeType { LUFF_EDGE, GAFF_EDGE, FOOT_EDGE, LEECH_EDGE };
 
-class layout_error : public runtime_error
+class layout_error : public std::runtime_error
 {
 public:
-    layout_error(const string &message) : runtime_error(message)
+    layout_error(const std::string &message) : std::runtime_error(message)
     {
-        cout << "in sailworker:" << what()  << endl;
+        std::cout << "in sailworker:" << what() << std::endl;
     }
 };
 

--- a/src/saildisp.cpp
+++ b/src/saildisp.cpp
@@ -165,7 +165,7 @@ real CSailDisp::zoom() const
  */
 void CSailDisp::setZoom(real zoom)
 {
-    m_zoom = max(ZOOM_MIN, min(zoom, ZOOM_MAX));
+    m_zoom = std::max(ZOOM_MIN, std::min(zoom, ZOOM_MAX));
 }
 
 

--- a/src/saildoc.cpp
+++ b/src/saildoc.cpp
@@ -179,7 +179,7 @@ void CSailDoc::get
  * @param name the name of the string
  */
 void CSailDoc::get
-( const QDomNode &parent, string &s, const QString &name )
+( const QDomNode &parent, std::string &s, const QString &name )
 {
     QDomElement e = findElement( parent, "string", name);
     QDomNamedNodeMap attr = e.attributes();
@@ -246,7 +246,7 @@ void CSailDoc::get
     }
     else
     {
-        throw invalid_argument("CSailDoc::get : unknown panel group type");
+        throw std::invalid_argument("CSailDoc::get : unknown panel group type");
     }
 }
 
@@ -700,7 +700,7 @@ void CSailDoc::put(QDomNode &parent, const real &r, const QString &name )
 
 /** Puts a std::string value to an XML document.
  */
-void CSailDoc::put(QDomNode &parent, const string &s, const QString &name )
+void CSailDoc::put(QDomNode &parent, const std::string &s, const QString &name )
 {
     QDomElement e = createElement("string", name, QString::fromStdString(s));
     parent.appendChild(e);

--- a/src/saildoc.h
+++ b/src/saildoc.h
@@ -30,12 +30,12 @@
 #include "prefs.h"
 
 
-class doc_element_error : public runtime_error
+class doc_element_error : public std::runtime_error
 {
 public:
-    doc_element_error(const string &message) : runtime_error(message)
+    doc_element_error(const std::string &message) : std::runtime_error(message)
     {
-        cout << what() << endl;
+        std::cout << what() << std::endl;
     }
 };
 
@@ -69,7 +69,7 @@ public:
     void get
     (const QDomNode &parent, real &r, const QString &name );
     void get
-    (const QDomNode &parent, string &s, const QString &name );
+    (const QDomNode &parent, std::string &s, const QString &name );
     void get
     (const QDomNode &parent, QString &s, const QString &name );
     void get
@@ -109,7 +109,7 @@ public:
     void put(QDomNode &parent, const int &i, const QString &name ="" );
     void put(QDomNode &parent, const unsigned int &i, const QString &name ="" );
     void put(QDomNode &parent, const real &r, const QString &name ="" );
-    void put(QDomNode &parent, const string &s, const QString &name="" );
+    void put(QDomNode &parent, const std::string &s, const QString &name="" );
     void put(QDomNode &parent, const QString &s, const QString &name="" );
     void put(QDomNode &parent, const CPoint3d &p, const QString &name="" );
     void put(QDomNode &parent, const enumBoatElementType &t, const QString &name="");
@@ -142,7 +142,7 @@ protected:
      */
     template<class myType>
     void get_vector
-    (QDomNode &parent, vector<myType>& v, const QString &name="")
+    (QDomNode &parent, std::vector<myType>& v, const QString &name="")
     {
         QDomElement e = findElement( parent, "vector", name);
         if ( e.isNull() )
@@ -165,7 +165,7 @@ protected:
      * @param name the name of the vector
      */
     template<class myType>
-    void put_vector(QDomNode &parent, const vector<myType>& v, const QString &name="")
+    void put_vector(QDomNode &parent, const std::vector<myType>& v, const QString &name="")
     {
         QDomElement e = createElement("vector",name);
         e.setAttribute("size", (unsigned int)v.size());

--- a/src/sailtreeitem.cpp
+++ b/src/sailtreeitem.cpp
@@ -37,7 +37,7 @@ CSailTreeItem::CSailTreeItem(const CPanelGroup &data, QString name, CSailTreeIte
     itemData << name;
     itemIcon = panelgroup_xpm;
     appendChild(new CSailTreeItem(data.title, "title", this));
-    appendChild(new CSailTreeItem((vector<CPanel>)(data), "panel", this));
+    appendChild(new CSailTreeItem(std::vector<CPanel>(data), "panel", this));
     if (data.child.size() > 0)
         appendChild(new CSailTreeItem(data.child, "child", this));
 }
@@ -60,7 +60,7 @@ CSailTreeItem::CSailTreeItem(const CPoint3d &data, QString name, CSailTreeItem *
     itemData << name << data.x() << data.y() << data.z();
 }
 
-CSailTreeItem::CSailTreeItem(const string &data, QString name, CSailTreeItem *parent)
+CSailTreeItem::CSailTreeItem(const std::string &data, QString name, CSailTreeItem *parent)
 {
     parentItem = parent;
     itemIcon = NULL;

--- a/src/sailtreeitem.h
+++ b/src/sailtreeitem.h
@@ -34,7 +34,7 @@ public:
     CSailTreeItem(const CPanelGroup& data, QString name, CSailTreeItem *parent = 0);
     CSailTreeItem(const CPanel& data, QString name, CSailTreeItem *parent = 0);
     CSailTreeItem(const CPoint3d& data, QString name, CSailTreeItem *parent = 0);
-    CSailTreeItem(const string& data, QString name, CSailTreeItem *parent = 0);
+    CSailTreeItem(const std::string& data, QString name, CSailTreeItem *parent = 0);
 
     /** Constructs a CSailTreeItem representing a vector of elements.
      *
@@ -43,7 +43,7 @@ public:
      * @param parent the parent node
      */
     template<class myType>
-    CSailTreeItem(const vector<myType>& v, QString name, CSailTreeItem *parent)
+    CSailTreeItem(const std::vector<myType>& v, QString name, CSailTreeItem *parent)
     {
         parentItem = parent;
         itemData << name;

--- a/src/sailviewer-tabs.h
+++ b/src/sailviewer-tabs.h
@@ -39,7 +39,7 @@ private slots:
 
 public:
     /** the widgets of each view */
-    vector<CSailViewerPanel *> panel;
+    std::vector<CSailViewerPanel*> panel;
 };
 
 #endif

--- a/src/sailwriter-carlson.cpp
+++ b/src/sailwriter-carlson.cpp
@@ -22,16 +22,17 @@
 #include <iomanip>
 #include <QFile>
 
+#define CRLF "\r\n"
 
 /** Write the draw message
  *
  * @param out the output stream
  * @param ct number of points to be written
  */
-void CSailCarlsonWriter::writeDraw(ofstream &out, unsigned int ct) const
+void CSailCarlsonWriter::writeDraw(std::ofstream &out, unsigned int ct) const
 {
-    out.setf(ios::left, ios::adjustfield);
-    out<< setw(16) <<"draw"<<  ct << CRLF;
+    out.setf(std::ios::left, std::ios::adjustfield);
+    out<< std::setw(16) <<"draw"<<  ct << CRLF;
 }
 
 
@@ -40,10 +41,10 @@ void CSailCarlsonWriter::writeDraw(ofstream &out, unsigned int ct) const
  * @param out the output stream
  * @param ct number of points to be written
  */
-void CSailCarlsonWriter::writeCut(ofstream &out, unsigned int ct) const
+void CSailCarlsonWriter::writeCut(std::ofstream &out, unsigned int ct) const
 {
-    out.setf(ios::left, ios::adjustfield);
-    out<< setw(16) <<"cut"<<  ct << CRLF;
+    out.setf(std::ios::left, std::ios::adjustfield);
+    out<< std::setw(16) <<"cut"<<  ct << CRLF;
 }
 
 
@@ -52,14 +53,14 @@ void CSailCarlsonWriter::writeCut(ofstream &out, unsigned int ct) const
  * @param out the output stream
  * @param p0 3d point to be written
  */
-void CSailCarlsonWriter::writePoint(ofstream &out, CPoint3d p0) const
+void CSailCarlsonWriter::writePoint(std::ofstream &out, CPoint3d p0) const
 {
     real x=0, y=0;
     x= p0.x();
     y= p0.y();
 
-    out.setf(ios::left, ios::adjustfield);
-    out << setw(16) << x << y << CRLF;
+    out.setf(std::ios::left, std::ios::adjustfield);
+    out << std::setw(16) << x << y << CRLF;
 }
 
 
@@ -69,7 +70,7 @@ void CSailCarlsonWriter::writePoint(ofstream &out, CPoint3d p0) const
  * @param panel the number of the panel to write
  *
  */
-void CSailCarlsonWriter::writePanelHeader(ofstream &out, const CPanel &panel) const
+void CSailCarlsonWriter::writePanelHeader(std::ofstream &out, const CPanel &panel) const
 {
     //char identity;
     //identity = panel.label.name;
@@ -91,9 +92,9 @@ void CSailCarlsonWriter::writePanelHeader(ofstream &out, const CPanel &panel) co
  */
 void CSailCarlsonWriter::write(const CPanelGroup &sail, const QString &filename) const
 {
-    ofstream out;
+    std::ofstream out;
 
-    out.open(QFile::encodeName(filename),ios::out);
+    out.open(QFile::encodeName(filename), std::ios::out);
     if (!out.is_open())
         throw write_error("CSailCarlsonWriter::write : unable to write to specified file");
 
@@ -114,7 +115,7 @@ void CSailCarlsonWriter::write(const CPanelGroup &sail, const QString &filename)
  * @param panel the number of the panel to write
  *
  */
-void CSailCarlsonWriter::writePanel(ofstream &out, const CPanel &panel) const
+void CSailCarlsonWriter::writePanel(std::ofstream &out, const CPanel &panel) const
 {
     CSide top = panel.top;
     CSide btm = panel.bottom;

--- a/src/sailwriter-carlson.h
+++ b/src/sailwriter-carlson.h
@@ -39,11 +39,11 @@ public:
     ;
 
     void write(const CPanelGroup &sail, const QString &filename) const;
-    void writePanel(ofstream &out, const CPanel &panel) const;
-    void writePanelHeader(ofstream &out, const CPanel &panel) const;
-    void writeDraw(ofstream &out, unsigned int ct) const;
-    void writeCut(ofstream &out, unsigned int ct) const;
-    void writePoint(ofstream &out, CPoint3d p0) const;
+    void writePanel(std::ofstream &out, const CPanel &panel) const;
+    void writePanelHeader(std::ofstream &out, const CPanel &panel) const;
+    void writeDraw(std::ofstream &out, unsigned int ct) const;
+    void writeCut(std::ofstream &out, unsigned int ct) const;
+    void writePoint(std::ofstream &out, CPoint3d p0) const;
 
 };
 

--- a/src/sailwriter-dxf.cpp
+++ b/src/sailwriter-dxf.cpp
@@ -52,9 +52,9 @@
  * @param code atom code
  * @param content atom content
  */
-void CSailDxfWriter::writeAtom(ofstream &out, int code, const QString& content) const
+void CSailDxfWriter::writeAtom(std::ofstream &out, int code, const QString& content) const
 {
-    out << code << endl << string(content.toLocal8Bit()) << endl;
+    out << code << std::endl << std::string(content.toLocal8Bit()) << std::endl;
 }
 
 
@@ -63,9 +63,9 @@ void CSailDxfWriter::writeAtom(ofstream &out, int code, const QString& content) 
  * @param out the output stream
  * @param filename the output file name
  */
-void CSailDxfWriter::writeBegin(ofstream &out, const QString &filename) const
+void CSailDxfWriter::writeBegin(std::ofstream &out, const QString &filename) const
 {
-    out.open(QFile::encodeName(filename),ios::out);
+    out.open(QFile::encodeName(filename), std::ios::out);
     if (!out.is_open())
         throw write_error("CSailDxfWriter::writeBegin : unable to write to specified file");
 
@@ -83,7 +83,7 @@ void CSailDxfWriter::writeBegin(ofstream &out, const QString &filename) const
  *
  * @param out the output stream
  */
-void CSailDxfWriter::writeEnd(ofstream &out) const
+void CSailDxfWriter::writeEnd(std::ofstream &out) const
 {
     writeAtom(out, DXF_ENTITY, "EOF");
     out.close();
@@ -98,14 +98,14 @@ void CSailDxfWriter::writeEnd(ofstream &out) const
  * @param p2 third point
  * @param layer
  */
-void CSailDxfWriter::writeFace(ofstream &out, CPoint3d p0, CPoint3d p1, CPoint3d p2, unsigned int layer) const
+void CSailDxfWriter::writeFace(std::ofstream &out, CPoint3d p0, CPoint3d p1, CPoint3d p2, unsigned int layer) const
 {
     // skip empty face
     real area = CVector3d::crossProduct(p1 - p0, p2 - p0).length();
-    //cout << "area : " << area << endl;
+    //std::cout << "area : " << area << std::endl;
     if ( area <= EPS )
     {
-        cout << "CSailDxfWriter::writeFace : skipping empty face" << endl;
+        std::cout << "CSailDxfWriter::writeFace : skipping empty face" << std::endl;
         return;
     }
 
@@ -138,7 +138,7 @@ void CSailDxfWriter::writeFace(ofstream &out, CPoint3d p0, CPoint3d p1, CPoint3d
  * @param layer
  * @param color the color
  */
-void CSailDxfWriter::writeLayer(ofstream &out, unsigned int layer, const QString &color) const
+void CSailDxfWriter::writeLayer(std::ofstream &out, unsigned int layer, const QString &color) const
 {
     writeAtom(out, DXF_ENTITY, "LAYER");
     writeAtom(out, DXF_NAME, QString::number(layer));
@@ -154,7 +154,7 @@ void CSailDxfWriter::writeLayer(ofstream &out, unsigned int layer, const QString
  * @param layer
  * @param color the color
  */
-void CSailDxfWriter::writePolyline(ofstream &out, unsigned int layer, const QString &color) const
+void CSailDxfWriter::writePolyline(std::ofstream &out, unsigned int layer, const QString &color) const
 {
     writeAtom(out, DXF_ENTITY, "POLYLINE");
     // set the layer
@@ -174,7 +174,7 @@ void CSailDxfWriter::writePolyline(ofstream &out, unsigned int layer, const QStr
  * @param pt point
  * @param layer
  */
-void CSailDxfWriter::writeVertex(ofstream &out, CPoint3d pt, unsigned int layer) const
+void CSailDxfWriter::writeVertex(std::ofstream &out, CPoint3d pt, unsigned int layer) const
 {
     writeAtom(out, DXF_ENTITY, "VERTEX");
     // set the layer
@@ -224,7 +224,7 @@ void CSailDxfWriter2d::write(const CPanelGroup &sail, const QString &filename) c
  */
 void CSailDxfWriter2d::writeNormal(const CPanelGroup &sail, const QString &filename) const
 {
-    ofstream out;
+    std::ofstream out;
     unsigned int pn;
 
     // open file, write comment and header
@@ -265,7 +265,7 @@ void CSailDxfWriter2d::writeNormal(const CPanelGroup &sail, const QString &filen
  */
 void CSailDxfWriter2d::writeBlocks(const CPanelGroup &sail, const QString &filename) const
 {
-    ofstream out;
+    std::ofstream out;
     unsigned int pn;
 
     // open file, write comment and header
@@ -317,9 +317,7 @@ void CSailDxfWriter2d::writeBlocks(const CPanelGroup &sail, const QString &filen
  */
 void CSailDxfWriter2d::writeSplit(const CPanelGroup &sail, const QString &basename) const
 {
-    //cout << "Not implemented yet" << endl;
-
-    ofstream out;
+    std::ofstream out;
     unsigned int pn;
 
     for (pn = 0; pn < sail.size(); pn++)
@@ -358,7 +356,7 @@ void CSailDxfWriter2d::writeSplit(const CPanelGroup &sail, const QString &basena
  * @param panel the panel to be written
  * @param layer the layer on which the panel is written
  */
-void CSailDxfWriter2d::writePanel(ofstream &out, const CPanel &panel, unsigned int layer) const
+void CSailDxfWriter2d::writePanel(std::ofstream &out, const CPanel &panel, unsigned int layer) const
 {
     //writeAtom(out, DXF_COMMENT, panel.label.name);
 
@@ -521,7 +519,7 @@ void CSailDxfWriter3d::write(const CPanelGroup &sail, const QString &filename) c
  */
 void CSailDxfWriter3d::writeNormal(const CPanelGroup &sail, const QString &filename) const
 {
-    ofstream out;
+    std::ofstream out;
     unsigned int pn;
 
     // open file, write comment and header
@@ -556,7 +554,7 @@ void CSailDxfWriter3d::writeNormal(const CPanelGroup &sail, const QString &filen
  * @param panel the number of the panel to be written
  * @param layer the layer on which the panel is written
  */
-void CSailDxfWriter3d::writePanel(ofstream &out, const CPanel &panel, unsigned int layer) const
+void CSailDxfWriter3d::writePanel(std::ofstream &out, const CPanel &panel, unsigned int layer) const
 {
     //writeAtom(out, DXF_COMMENT, panel.label.name);
     //writeAtom(out, DXF_COMMENT, QString("panel : ") + QString::number(panel));
@@ -593,7 +591,7 @@ void CSailDxfWriter3d::writePanel(ofstream &out, const CPanel &panel, unsigned i
  */
 void CSailDxfWriter3d::writeSplit(const CPanelGroup &sail, const QString &basename) const
 {
-    ofstream out;
+    std::ofstream out;
 
     for (unsigned int pn = 0; pn < sail.size(); pn++)
     {

--- a/src/sailwriter-dxf.h
+++ b/src/sailwriter-dxf.h
@@ -36,14 +36,14 @@ public:
     {}
     ;
 
-    void writeBegin(ofstream &out, const QString &filename) const;
-    void writeEnd(ofstream &out) const;
+    void writeBegin(std::ofstream &out, const QString &filename) const;
+    void writeEnd(std::ofstream &out) const;
 
-    void writeAtom(ofstream &out, int code, const QString& content) const;
-    void writeFace(ofstream &out, CPoint3d p0, CPoint3d p1, CPoint3d p2, unsigned int layer) const;
-    void writeLayer(ofstream &out, unsigned int layer, const QString &color) const;
-    void writePolyline(ofstream &out, unsigned int layer, const QString &color) const;
-    void writeVertex(ofstream &out, CPoint3d p0, unsigned int layer) const;
+    void writeAtom(std::ofstream &out, int code, const QString& content) const;
+    void writeFace(std::ofstream &out, CPoint3d p0, CPoint3d p1, CPoint3d p2, unsigned int layer) const;
+    void writeLayer(std::ofstream &out, unsigned int layer, const QString &color) const;
+    void writePolyline(std::ofstream &out, unsigned int layer, const QString &color) const;
+    void writeVertex(std::ofstream &out, CPoint3d p0, unsigned int layer) const;
 };
 
 
@@ -64,7 +64,7 @@ public:
     void write(const CPanelGroup &sail, const QString &filename) const;
 
 protected:
-    void writePanel(ofstream &out, const CPanel &panel, unsigned int layer) const;
+    void writePanel(std::ofstream &out, const CPanel &panel, unsigned int layer) const;
 
     void writeNormal(const CPanelGroup &sail, const QString &filename) const;
     void writeBlocks(const CPanelGroup &sail, const QString &filename) const;
@@ -90,7 +90,7 @@ public:
     void write(const CPanelGroup &sail, const QString &filename) const;
 
 protected:
-    void writePanel(ofstream &out, const CPanel &panel, unsigned int layer) const;
+    void writePanel(std::ofstream &out, const CPanel &panel, unsigned int layer) const;
 
     void writeNormal(const CPanelGroup &sail, const QString &filename) const;
     void writeSplit(const CPanelGroup &sail, const QString &filename) const;

--- a/src/sailwriter-hand.cpp
+++ b/src/sailwriter-hand.cpp
@@ -30,32 +30,32 @@
 void CSailHandWriter::write(const CPanelGroup &sail, const QString &filename) const
 {
     // open the output file
-    ofstream myOut;
-    myOut.open(QFile::encodeName(filename), ios::out);
+    std::ofstream myOut;
+    myOut.open(QFile::encodeName(filename), std::ios::out);
     if (!myOut.is_open())
         throw write_error("CSailWriter::write : unable to write to specified file");
 
     // write the name of the sail
-    myOut << sail.title << endl;
+    myOut << sail.title << std::endl;
 
     // TODO : modify code to write actual hand output
     //
     // sail is the sail, loop over its panels
     for (unsigned int i=0; i < sail.size(); i++)
     {
-        myOut << "===== CPanel : " << i << " ====" << endl;
+        myOut << "===== CPanel : " << i << " ====" << std::endl;
         myOut << sail[i].label;
-        myOut << "== CSide : left ==" << endl << sail[i].left;
-        myOut << "== CSide : top ==" << endl << sail[i].top;
-        myOut << "== CSide : right ==" << endl << sail[i].right;
-        myOut << "== CSide : bottom ==" << endl << sail[i].bottom;
+        myOut << "== CSide : left ==" << std::endl << sail[i].left;
+        myOut << "== CSide : top ==" << std::endl << sail[i].top;
+        myOut << "== CSide : right ==" << std::endl << sail[i].right;
+        myOut << "== CSide : bottom ==" << std::endl << sail[i].bottom;
 
         if (sail[i].hasHems)
         {
-            myOut << "== CSide : cutLeft ==" << endl << sail[i].cutLeft;
-            myOut << "== CSide : cutTop ==" << endl << sail[i].cutTop;
-            myOut << "== CSide : cutRight ==" << endl << sail[i].cutRight;
-            myOut << "== CSide : cutBottom ==" << endl << sail[i].cutBottom;
+            myOut << "== CSide : cutLeft ==" << std::endl << sail[i].cutLeft;
+            myOut << "== CSide : cutTop ==" << std::endl << sail[i].cutTop;
+            myOut << "== CSide : cutRight ==" << std::endl << sail[i].cutRight;
+            myOut << "== CSide : cutBottom ==" << std::endl << sail[i].cutBottom;
         }
     }
 

--- a/src/sailwriter-txt.cpp
+++ b/src/sailwriter-txt.cpp
@@ -29,11 +29,11 @@
  */
 void CSailTxtWriter::write(const CPanelGroup &sail, const QString &filename) const
 {
-    ofstream myOut;
-    myOut.open(QFile::encodeName(filename), ios::out);
+    std::ofstream myOut;
+    myOut.open(QFile::encodeName(filename), std::ios::out);
     if (!myOut.is_open())
         throw write_error("CSailTxtWriter::write : unable to write to specified file");
-    myOut << sail.title << endl;
+    myOut << sail.title << std::endl;
     myOut << sail;
     myOut.close();
 }

--- a/tests/geocpp/tst_geocpp.cpp
+++ b/tests/geocpp/tst_geocpp.cpp
@@ -31,7 +31,7 @@
 
 /** Outputs a CMatrix to a stream.
  */
-ostream& operator<< (ostream &o, const CMatrix &m)
+std::ostream& operator<< (std::ostream &o, const CMatrix &m)
 {
     o << "[";
     for (size_t i = 0 ; i < m.rows() ; ++i)
@@ -39,7 +39,7 @@ ostream& operator<< (ostream &o, const CMatrix &m)
         for (size_t j = 0; j < m.columns(); ++j)
             o << m(i, j);
         if ( i != m.rows() - 1 )
-            o << endl;
+            o << std::endl;
     }
     o << "]";
     return o;


### PR DESCRIPTION
We want to explicitly identify standard library types and methods.