### PR TITLE
Refactor CPanel::reframe() to fix compilation warning

### DIFF
--- a/src/sailcpp/panel.cpp
+++ b/src/sailcpp/panel.cpp
@@ -319,7 +319,7 @@ CPanel CPanel::develop(enumDevelopAlign align) const
     flatpanel.hasHems = false;
 
     /** frame the developed panel to be X>0 and Y>0 */
-    flatpanel = flatpanel.reframe(LOW_LEFT);
+    flatpanel.reframe();
 
     return flatpanel;
 }
@@ -331,87 +331,19 @@ void CPanel::placeLabel()
 }
 
 
-/** Reframe a panel such that the most left/right/top/bottom
- *  point is at coordinate X or Y =0
+/** Translate the panel so that the most left / bottom points
+ *  are at coordinates X=0, Y =0.
  */
-CPanel CPanel::reframe(enumAlign align) const
+void CPanel::reframe()
 {
-    unsigned int npl = left.size();   // number of right/left points
-    unsigned int npb = bottom.size();  // number of top/bottom points
-    unsigned int i;
-    real xm=11111, ym=11111;
-
-    switch ( align )
-    {
-    case LEFT:
-        if ( hasHems == true )
-        {
-            for (i = 0 ; i < npl ; i++)
-            {
-                if ( cutRight[i].x() > xm )
-                    xm = cutRight[i].x();
-            }
-        }
-        else
-        {
-            for (i = 0 ; i < npl ; i++)
-            {
-                if ( right[i].x() > xm )
-                    xm = right[i].x();
-            }
-        }
-
-    case BOTTOM:
-        if ( hasHems == true )
-        {
-            for (i = 0 ; i < npb ; i++)
-            {
-                if ( cutBottom[i].y() < ym )
-                    ym = cutBottom[i].y();
-            }
-        }
-        else
-        {
-            for (i = 0; i < npb; i++)
-            {
-                if ( bottom[i].y() < ym )
-                    ym = bottom[i].y();
-            }
-        }
-
-    case LOW_LEFT:
-        if ( hasHems ==  true )
-        {
-            for (i = 0; i < npl; i++)
-            {
-                if ( cutLeft[i].x() < xm )
-                    xm = cutLeft[i].x();
-            }
-
-            for (i = 0; i < npb; i++)
-            {
-                if ( cutBottom[i].y() < ym )
-                    ym = cutBottom[i].y();
-            }
-        }
-        else
-        {
-            for (i = 0; i < npl; i++)
-            {
-                if ( left[i].x() < xm )
-                    xm = left[i].x();
-            }
-
-            for (i = 0; i < npb; i++)
-            {
-                if ( bottom[i].y() < ym )
-                    ym = bottom[i].y();
-            }
-        }
+    if (hasHems) {
+        *this = *this + CVector3d(-cutLeft.left(), -cutBottom.bottom(), 0);
+    } else {
+        *this = *this + CVector3d(-left.left(), -bottom.bottom(), 0);
     }
-
-    return (*this + CVector3d( -xm , -ym , 0 ));
 }
+
+
 /** Add the cloth for stitching to the 4 edges of the panel.
  *  This create the panel to be cut (outside the basic panel)
  *   lw = width to be added on left side
@@ -926,6 +858,38 @@ void CSide::fill( const CPoint3d &p1 , const CPoint3d &p2 , const CPoint3d &p3 )
             at(i) = p1 + (p2 - p1) * (real(i) / n1);
         else
             at(i) = p2 + (p3 - p2) * (real(i - n1) / (size() -n1 -1) );
+    }
+}
+
+
+/** Returns the y-coordinate of the bottom-most point.
+ */
+ real CSide::bottom() const
+ {
+     if (size()) {
+         real y = at(0).y();
+         for (unsigned int i = 1; i < size(); i++) {
+             y = std::min(y, at(i).y());
+         }
+         return y;
+     } else {
+         return 0;
+     }
+}
+
+
+/** Returns the x-coordinate of the left-most point.
+ */
+real CSide::left() const
+{
+    if (size()) {
+        real x = at(0).x();
+        for (unsigned int i = 1; i < size(); i++) {
+            x = std::min(x, at(i).x());
+        }
+        return x;
+    } else {
+        return 0;
     }
 }
 

--- a/src/sailcpp/panel.h
+++ b/src/sailcpp/panel.h
@@ -28,7 +28,6 @@
 #include <geocpp/geocpp.h>
 
 enum enumPointType { LUFF, FOOT, LEECH, GAFF };
-enum enumAlign {LEFT, LOW_LEFT, BOTTOM};
 enum enumDevelopAlign {ALIGN_TOP,ALIGN_BOTTOM };
 
 class panel_error : public std::runtime_error
@@ -95,6 +94,9 @@ public:
 public:
     void fill( const CPoint3d &, const CPoint3d & );
     void fill( const CPoint3d &, const CPoint3d &, const CPoint3d & );
+
+    real bottom() const;
+    real left() const;
 
     CSide transformed(const CMatrix4x4 &m) const;
 
@@ -174,7 +176,7 @@ public:
     CPanel develop(enumDevelopAlign align) const;
 
     void placeLabel();   //  place a label at the center of a panel
-    CPanel reframe(enumAlign align) const;
+    void reframe();
     CPanel rotated(const CPoint3d &, real angle, Qt::Axis axis) const;
     CPanel transformed(const CMatrix4x4 &m) const;
     CPanel operator+ (const CVector3d &) const;

--- a/src/sailcpp/sailworker.cpp
+++ b/src/sailcpp/sailworker.cpp
@@ -531,7 +531,7 @@ CPanelGroup CSailWorker::Layout0( CPanelGroup &flatsail, CPanelGroup &dispsail )
         /** Reposition the developed panel such that the
         *  lowest point is Y=0 AND most left point is X=0.
         */
-        dev[npanel-1] = dev[npanel-1].reframe(LOW_LEFT);
+        dev[npanel-1].reframe();
 
         /* check if peak has been reached to break off */
         if ( flag == true )
@@ -843,7 +843,7 @@ CPanelGroup CSailWorker::LayoutTwist( CPanelGroup &flatsail, CPanelGroup &dispsa
 
         /* Now we reposition the developed panel such that
          *  bottom minimum is Y=0 AND most left point is X=0 */
-        dev[npanel-1] = dev[npanel-1].reframe(LOW_LEFT);
+        dev[npanel-1].reframe();
 
         /* check if peak has been reached to break off */
         if ( flag == true )
@@ -1069,7 +1069,7 @@ CPanelGroup CSailWorker::LayoutVertical( CPanelGroup &flatsail, CPanelGroup &dis
         deviaPrev = deviation;
 
         /* Now we reposition the developed panel such that bottom left is X=0 Y=0 */
-        dev[npanel-1] = dev[npanel-1].reframe(LOW_LEFT);
+        dev[npanel-1].reframe();
 
         /* check if peak has been reached to break off */
         if ( flag == true )
@@ -1381,7 +1381,7 @@ CPanelGroup CSailWorker::LayoutWing( CPanelGroup &flatsail, CPanelGroup &dispsai
         /* Reposition the developed panel such that
         *  bottom minimum is Y=0 AND most left is X=0
         */
-        dev[npanel-1] = dev[npanel-1].reframe(LOW_LEFT);
+        dev[npanel-1].reframe();
 
         /* check if peak has been reached to break off */
         if ( flag == true )
@@ -2574,7 +2574,7 @@ CPanelGroup CSailWorker::LayoutMitre( CPanelGroup &flatsail, CPanelGroup &dispsa
         deviaPrev = deviation;
 
         /* Now we reposition the developed panel such that bottom left is X=0 Y=0 */
-        dev[npanel-1] = dev[npanel-1].reframe(LOW_LEFT);
+        dev[npanel-1].reframe();
 
         /* check if peak has been reached to break off */
         if ( flag == true )
@@ -2789,7 +2789,7 @@ CPanelGroup CSailWorker::LayoutMitre( CPanelGroup &flatsail, CPanelGroup &dispsa
             deviaPrev[k] = deviation[k];
 
         /* Now we reposition the developed panel such that bottom left is X=0 Y=0 */
-        dev[npanel-1] = dev[npanel-1].reframe(LOW_LEFT);
+        dev[npanel-1].reframe();
 
         /* check if peak has been reached to break off */
         if ( flag == true )
@@ -2987,7 +2987,7 @@ CPanelGroup CSailWorker::LayoutMitre2( CPanelGroup &flatsail, CPanelGroup &disps
          deviaPrev = deviation;
 
         /* Reposition the developed panel such that bottom left is X=0 Y=0 */
-        dev[npanel-1] = dev[npanel-1].reframe(LOW_LEFT);
+        dev[npanel-1].reframe();
 
         /* Check if peak has been reached to break off */
         if ( flag == true )
@@ -3140,7 +3140,7 @@ CPanelGroup CSailWorker::LayoutMitre2( CPanelGroup &flatsail, CPanelGroup &disps
         deviaPrev = deviation;
 
         /* Now we reposition the developed panel such that bottom left is X=0 Y=0 */
-        dev[npanel-1] = dev[npanel-1].reframe(LOW_LEFT);
+        dev[npanel-1].reframe();
 
         /* check if peak has been reached to break off */
         if ( flag == true )

--- a/tests/sailcpp/sailcpp.pro
+++ b/tests/sailcpp/sailcpp.pro
@@ -1,0 +1,12 @@
+include(../tests.pri)
+TARGET = tst_sailcpp
+
+SOURCES += \
+    ../../src/geocpp/matrix.cpp \
+    ../../src/geocpp/matrix4x4.cpp \
+    ../../src/geocpp/rect.cpp \
+    ../../src/geocpp/subspace.cpp \
+    ../../src/geocpp/vector.cpp \
+    ../../src/sailcpp/panel.cpp \
+    ../../src/sailcpp/sailcalc.cpp \
+    tst_sailcpp.cpp

--- a/tests/sailcpp/tst_sailcpp.cpp
+++ b/tests/sailcpp/tst_sailcpp.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 1993-2018 Robert & Jeremy Laine
+ * See AUTHORS file for a full list of contributors.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <cstdlib>
+#include <ctime>
+
+#include <QObject>
+#include <QtTest>
+
+#include "geocpp/geocpp.h"
+#include "sailcpp/panel.h"
+
+class tst_SailCpp : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testSide();
+};
+
+void tst_SailCpp::testSide()
+{
+    CSide side(0);
+
+    // Empty.
+    QCOMPARE(side.left(), 0);
+    QCOMPARE(side.bottom(), 0);
+
+    // 1 point.
+    side.push_back(CPoint3d(1, 2, 3));
+    QCOMPARE(side.left(), 1);
+    QCOMPARE(side.bottom(), 2);
+
+    // 2 points
+    side.push_back(CPoint3d(2, 3, 4));
+    QCOMPARE(side.left(), 1);
+    QCOMPARE(side.bottom(), 2);
+
+    // 2 points
+    side.push_back(CPoint3d(-1, -2, -3));
+    QCOMPARE(side.left(), -1);
+    QCOMPARE(side.bottom(), -2);
+}
+
+QTEST_MAIN(tst_SailCpp)
+#include "tst_sailcpp.moc"

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,2 +1,2 @@
 TEMPLATE = subdirs
-SUBDIRS = geocpp
+SUBDIRS = geocpp sailcpp


### PR DESCRIPTION
Simplify CPanel::reframe by:

- Only supporting alignment on the left/bottom corner, this is the only one being used.
- Modifying the panel in place instead of returning a new panel.
- Adding `left()` and `bottom()` methods to `CSide`.